### PR TITLE
fix: correct spelling of "ammended" to "amended" in tooltip

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -318,7 +318,7 @@
 
 					{#if conflicted}
 						<Tooltip
-							text={"Conflicted commits must be resolved before they can be ammended or squashed.\nPlease resolve conflicts using the 'Resolve conflicts' button"}
+							text={"Conflicted commits must be resolved before they can be amended or squashed.\nPlease resolve conflicts using the 'Resolve conflicts' button"}
 						>
 							<div class="commit__conflicted">
 								<Icon name="warning-small" />


### PR DESCRIPTION
Update the tooltip text in CommitCard.svelte to fix the spelling 
error of "ammended" to "amended." This improves the clarity and 
professionalism of the user interface by ensuring correct language 
usage.